### PR TITLE
Setup CI instance for Windows.

### DIFF
--- a/.github/workflows/win.yaml
+++ b/.github/workflows/win.yaml
@@ -1,0 +1,19 @@
+name: Build
+on: [push]
+
+jobs:
+  build_msvc:
+    name: Visual Studio Building
+    runs-on: windows-2019
+    steps:
+    - name: Setup msbuild
+      uses: microsoft/setup-msbuild@v1.0.0
+    - name: Install Windows 8.1 SDK
+      shell: powershell
+      run: |
+        Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile sdksetup.exe -UseBasicParsing
+        Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      run: msbuild CnCRemastered.sln


### PR DESCRIPTION
Chose GitHub Actions over Travis because the latter is a nightmare to
setup.
Optimization potential might be in storing the Windows 8.1 SDK in
Artifacts instead of downloading from Microsoft.