### PR TITLE
Only use Mono_Printf when necessary

### DIFF
--- a/REDALERT/COMBUF.CPP
+++ b/REDALERT/COMBUF.CPP
@@ -865,31 +865,31 @@ void CommBufferClass::Mono_Debug_Print(int refresh)
 	//------------------------------------------------------------------------
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	//------------------------------------------------------------------------
@@ -913,7 +913,7 @@ void CommBufferClass::Mono_Debug_Print(int refresh)
 				SendQueue[i].IsACK);
 		}
 		else {
-			Mono_Printf ("____ __  _ ");
+			Mono_Print ("____ __  _ ");
 		}
 
 		row++;
@@ -942,7 +942,7 @@ void CommBufferClass::Mono_Debug_Print(int refresh)
 				ReceiveQueue[i].IsACK);
 		}
 		else {
-			Mono_Printf ("____  _  _ ");
+			Mono_Print ("____  _  _ ");
 		}
 
 		row++;
@@ -995,31 +995,31 @@ void CommBufferClass::Mono_Debug_Print2(int refresh)
 	//------------------------------------------------------------------------
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	//------------------------------------------------------------------------
@@ -1075,14 +1075,14 @@ void CommBufferClass::Mono_Debug_Print2(int refresh)
 					SendQueue[i].IsACK);
 			}
 
-			Mono_Printf("%s",txt);
+			Mono_Print(txt);
 		}
 		else {
 
 			//..................................................................
 			//	Entry isn't active; print blanks
 			//..................................................................
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 
@@ -1139,14 +1139,14 @@ void CommBufferClass::Mono_Debug_Print2(int refresh)
 					ReceiveQueue[i].IsACK);
 			}
 
-			Mono_Printf("%s",txt);
+			Mono_Print(txt);
 		}
 		else {
 
 			//..................................................................
 			//	Entry isn't active; print blanks
 			//..................................................................
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 

--- a/REDALERT/COMQUEUE.CPP
+++ b/REDALERT/COMQUEUE.CPP
@@ -730,31 +730,31 @@ void CommQueueClass::Mono_Debug_Print(int refresh)
 	*/
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	/*
@@ -776,7 +776,7 @@ void CommQueueClass::Mono_Debug_Print(int refresh)
 			Mono_Printf ("%4d %2d  %d",hdr->PacketID, SendQueue[i].SendCount,
 				SendQueue[i].IsACK);
 		} else {
-			Mono_Printf ("____ __  _ ");
+			Mono_Print ("____ __  _ ");
 		}
 
 		row++;
@@ -803,7 +803,7 @@ void CommQueueClass::Mono_Debug_Print(int refresh)
 			Mono_Printf ("%4d  %d  %d",hdr->PacketID, ReceiveQueue[i].IsRead,
 				ReceiveQueue[i].IsACK);
 		} else {
-			Mono_Printf ("____  _  _ ");
+			Mono_Print ("____  _  _ ");
 		}
 
 		row++;
@@ -856,31 +856,31 @@ void CommQueueClass::Mono_Debug_Print2(int refresh)
 	*/
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	/*
@@ -935,7 +935,7 @@ void CommQueueClass::Mono_Debug_Print2(int refresh)
 			/*
 			**	Entry isn't active; print blanks
 			*/
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 
@@ -989,7 +989,7 @@ void CommQueueClass::Mono_Debug_Print2(int refresh)
 			/*
 			**	Entry isn't active; print blanks
 			*/
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 

--- a/REDALERT/CONQUER.CPP
+++ b/REDALERT/CONQUER.CPP
@@ -2866,7 +2866,7 @@ void Play_Movie(char const * name, ThemeType theme, bool clrscrn, bool immediate
 		return;
 	}
 	#ifdef CHEAT_KEYS
-	//	Mono_Printf("A\n");
+	//	Mono_Print("A\n");
 	#endif	//CHEAT_KEYS
 	/*
 	** Don't play movies in multiplayer mode
@@ -2875,7 +2875,7 @@ void Play_Movie(char const * name, ThemeType theme, bool clrscrn, bool immediate
 		return;
 	}
 	#ifdef CHEAT_KEYS
-	//Mono_Printf("b\n");
+	//Mono_Print("b\n");
 	#endif	//CHEAT_KEYS
 
 	if (name) {
@@ -2997,7 +2997,7 @@ void Play_Movie(char const * name, ThemeType theme, bool clrscrn, bool immediate
 			assert(vqa != NULL);
 		}
 		#ifdef CHEAT_KEYS
-		//Mono_Printf("d");
+		//Mono_Print("d");
 		#endif	//CHEAT_KEYS
 		/*
 		**	Presume that the screen is left in a garbage state as well as the palette

--- a/REDALERT/INIT.CPP
+++ b/REDALERT/INIT.CPP
@@ -355,7 +355,7 @@ bool Init_Game(int , char * [])
 	*/
 	if (!Special.IsFromInstall && !Special.IsFromWChat) {
 		VisiblePage.Clear();
-//		Mono_Printf("Playing Intro\n");
+//		Mono_Print("Playing Intro\n");
 		Play_Intro();
 		memset(CurrentPalette, 0x01, 768);
 		WhitePalette.Set();

--- a/REDALERT/IPXMGR.CPP
+++ b/REDALERT/IPXMGR.CPP
@@ -1756,16 +1756,16 @@ void IPXManagerClass::Mono_Debug_Print(int index, int refresh)
 
 	if (refresh) {
 		Mono_Set_Cursor (20,1);
-		Mono_Printf ("IPX Queue:");
+		Mono_Print ("IPX Queue:");
 
 		Mono_Set_Cursor (9,2);
-		Mono_Printf ("Average Response Time:");
+		Mono_Print ("Average Response Time:");
 
 		Mono_Set_Cursor (43,1);
-		Mono_Printf ("Send Overflows:");
+		Mono_Print ("Send Overflows:");
 
 		Mono_Set_Cursor (40,2);
-		Mono_Printf ("Receive Overflows:");
+		Mono_Print ("Receive Overflows:");
 
 	}
 
@@ -1796,7 +1796,7 @@ void IPXManagerClass::Mono_Debug_Print(int index, int refresh)
 	}
 	txt[i] = 0;
 	Mono_Set_Cursor ((80-NumBufs)/2,3);
-	Mono_Printf ("%s",txt);
+	Mono_Print (txt);
 
 #else
 	index = index;

--- a/REDALERT/MAPEDIT.CPP
+++ b/REDALERT/MAPEDIT.CPP
@@ -2146,7 +2146,7 @@ void MapEditClass::Read_INI(CCINIClass & ini)
 	/*
 	**	Invoke parent's Read_INI
 	*/
-	Mono_Printf("We are in Read_INI\n");
+	Mono_Print("We are in Read_INI\n");
 
 	MouseClass::Read_INI(ini);
 	BaseGauge->Set_Value(Scen.Percent);

--- a/REDALERT/NULLDLG.CPP
+++ b/REDALERT/NULLDLG.CPP
@@ -7558,7 +7558,7 @@ void Smart_Printf( char *format, ... )
 
 	if (Debug_Smart_Print) {
 		if (MonoClass::Is_Enabled()) {
-			Mono_Printf("%s",buf);
+			Mono_Print(buf);
 		} else {
 			printf("%s",buf);
 		}

--- a/REDALERT/NULLMGR.CPP
+++ b/REDALERT/NULLMGR.CPP
@@ -1348,19 +1348,19 @@ void NullModemClass::Mono_Debug_Print(int,int refresh)
 
 	if (refresh) {
 		Mono_Set_Cursor (31,1);
-		Mono_Printf ("Serial Port Queues");
+		Mono_Print ("Serial Port Queues");
 
 		Mono_Set_Cursor (9,2);
-		Mono_Printf ("Average Response Time:");
+		Mono_Print ("Average Response Time:");
 
 		Mono_Set_Cursor (20,3);
-		Mono_Printf ("CRC Errors:");
+		Mono_Print ("CRC Errors:");
 
 		Mono_Set_Cursor (43,2);
-		Mono_Printf ("Send Overflows:");
+		Mono_Print ("Send Overflows:");
 
 		Mono_Set_Cursor (40,3);
-		Mono_Printf ("Receive Overflows:");
+		Mono_Print ("Receive Overflows:");
 	}
 
 	Mono_Set_Cursor (32,2);

--- a/REDALERT/QUEUE.CPP
+++ b/REDALERT/QUEUE.CPP
@@ -4285,20 +4285,20 @@ static void Init_Queue_Mono(ConnManClass *net)
 		else {
 			if (NewMonoMode) {
 				Mono_Clear_Screen();
-				Mono_Printf("                         Queue AI:\n");	// flowcount[0]
-				Mono_Printf("                Build Packet Loop:\n");	// flowcount[1]
-				Mono_Printf("                       Frame Sync:\n");	// flowcount[2]
-				Mono_Printf("                Frame Sync Resend:\n");	// flowcount[3]
-				Mono_Printf("               Frame Sync Timeout:\n");	// flowcount[4]
-				Mono_Printf("           Frame Sync New Message:\n");	// flowcount[5]
-				Mono_Printf("                 DoList Execution:\n");	// flowcount[6]
-				Mono_Printf("                  DoList Cleaning:\n");	// flowcount[7]
-				Mono_Printf("\n");
-				Mono_Printf("                            Frame:\n");
-				Mono_Printf("                 Session.MaxAhead:\n");
-				Mono_Printf("                       their_recv:\n");
-				Mono_Printf("                       their_sent:\n");
-				Mono_Printf("                          my_sent:\n");
+				Mono_Print("                         Queue AI:\n");	// flowcount[0]
+				Mono_Print("                Build Packet Loop:\n");	// flowcount[1]
+				Mono_Print("                       Frame Sync:\n");	// flowcount[2]
+				Mono_Print("                Frame Sync Resend:\n");	// flowcount[3]
+				Mono_Print("               Frame Sync Timeout:\n");	// flowcount[4]
+				Mono_Print("           Frame Sync New Message:\n");	// flowcount[5]
+				Mono_Print("                 DoList Execution:\n");	// flowcount[6]
+				Mono_Print("                  DoList Cleaning:\n");	// flowcount[7]
+				Mono_Print("\n");
+				Mono_Print("                            Frame:\n");
+				Mono_Print("                 Session.MaxAhead:\n");
+				Mono_Print("                       their_recv:\n");
+				Mono_Print("                       their_sent:\n");
+				Mono_Print("                          my_sent:\n");
 				NewMonoMode = 0;
 			}
 		}

--- a/REDALERT/SCENARIO.CPP
+++ b/REDALERT/SCENARIO.CPP
@@ -961,7 +961,7 @@ void Do_Win(void)
 			Show_Mouse();
 #ifdef FIXIT_ANTS
 			AntsEnabled = false;
-//			Mono_Printf("Scenario.cpp one time only antsenabled is false\n");
+//			Mono_Print("Scenario.cpp one time only antsenabled is false\n");
 #endif
 			return;
 		}
@@ -1194,7 +1194,7 @@ void Do_Lose(void)
 	VisiblePage.Clear();
 	Show_Mouse();
 #ifdef CHEAT_KEYS
-//	Mono_Printf("Trying to play lose movie\n");
+//	Mono_Print("Trying to play lose movie\n");
 #endif //CHEAT_KEYS
 	Play_Movie(Scen.LoseMovie);
 
@@ -2127,7 +2127,7 @@ bool Read_Scenario_INI(char * fname, bool )
 						RequiredCD = 1;
 					} else {
 						if (Scen.ScenarioName[2] == 'G') {
-//							Mono_Printf("We are setting REquiredCD to 0");
+//							Mono_Print("We are setting REquiredCD to 0");
 							RequiredCD = 0;
 
 						}
@@ -2176,7 +2176,7 @@ bool Read_Scenario_INI(char * fname, bool )
 
 	int result = ini.Load(file, true);
 	if (result == 0) {
-//		Mono_Printf("ini.Load failed");
+//		Mono_Print("ini.Load failed");
 		GlyphX_Debug_Print("Failed to load scenario file");
 		GlyphX_Debug_Print(fname);
 		return(false);

--- a/REDALERT/WINSTUB.CPP
+++ b/REDALERT/WINSTUB.CPP
@@ -739,7 +739,7 @@ void Assert_Failure (char *expression, int line, char *file)
 	if (!MonoClass::Is_Enabled()) MonoClass::Enable();
 
 	Mono_Clear_Screen();
-	Mono_Printf("%s", assertbuf);
+	Mono_Print(assertbuf);
 
 	WWDebugString(assertbuf);
 

--- a/TIBERIANDAWN/COMBUF.CPP
+++ b/TIBERIANDAWN/COMBUF.CPP
@@ -762,31 +762,31 @@ void CommBufferClass::Mono_Debug_Print(int refresh)
 	------------------------------------------------------------------------*/
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	/*------------------------------------------------------------------------
@@ -808,7 +808,7 @@ void CommBufferClass::Mono_Debug_Print(int refresh)
 			Mono_Printf ("%4d %2d  %d",hdr->PacketID, SendQueue[i].SendCount,
 				SendQueue[i].IsACK);
 		} else {
-			Mono_Printf ("____ __  _ ");
+			Mono_Print ("____ __  _ ");
 		}
 
 		row++;
@@ -835,7 +835,7 @@ void CommBufferClass::Mono_Debug_Print(int refresh)
 			Mono_Printf ("%4d  %d  %d",hdr->PacketID, ReceiveQueue[i].IsRead,
 				ReceiveQueue[i].IsACK);
 		} else {
-			Mono_Printf ("____  _  _ ");
+			Mono_Print ("____  _  _ ");
 		}
 
 		row++;
@@ -888,31 +888,31 @@ void CommBufferClass::Mono_Debug_Print2(int refresh)
 	------------------------------------------------------------------------*/
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	/*------------------------------------------------------------------------
@@ -961,13 +961,13 @@ void CommBufferClass::Mono_Debug_Print2(int refresh)
 				sprintf(txt + strlen(txt),"                    %x",SendQueue[i].IsACK);
 			}
 
-			Mono_Printf("%s",txt);
+			Mono_Print(txt);
 		} else {
 
 			/*.....................................................................
 			Entry isn't active; print blanks
 			.....................................................................*/
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 
@@ -1018,13 +1018,13 @@ void CommBufferClass::Mono_Debug_Print2(int refresh)
 				sprintf(txt + strlen(txt),"                    %x",ReceiveQueue[i].IsACK);
 			}
 
-			Mono_Printf("%s",txt);
+			Mono_Print(txt);
 		} else {
 
 			/*.....................................................................
 			Entry isn't active; print blanks
 			.....................................................................*/
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 

--- a/TIBERIANDAWN/COMQUEUE.CPP
+++ b/TIBERIANDAWN/COMQUEUE.CPP
@@ -738,31 +738,31 @@ void CommQueueClass::Mono_Debug_Print(int refresh)
 	------------------------------------------------------------------------*/
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct ACK   ID  Ct ACK    ID  Ct ACK│ ID  Rd ACK    ID  Rd ACK   ID  Rd ACK│\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	/*------------------------------------------------------------------------
@@ -784,7 +784,7 @@ void CommQueueClass::Mono_Debug_Print(int refresh)
 			Mono_Printf ("%4d %2d  %d",hdr->PacketID, SendQueue[i].SendCount,
 				SendQueue[i].IsACK);
 		} else {
-			Mono_Printf ("____ __  _ ");
+			Mono_Print ("____ __  _ ");
 		}
 
 		row++;
@@ -811,7 +811,7 @@ void CommQueueClass::Mono_Debug_Print(int refresh)
 			Mono_Printf ("%4d  %d  %d",hdr->PacketID, ReceiveQueue[i].IsRead,
 				ReceiveQueue[i].IsACK);
 		} else {
-			Mono_Printf ("____  _  _ ");
+			Mono_Print ("____  _  _ ");
 		}
 
 		row++;
@@ -864,31 +864,31 @@ void CommQueueClass::Mono_Debug_Print2(int refresh)
 	------------------------------------------------------------------------*/
 	if (refresh) {
 		Mono_Clear_Screen ();
-		Mono_Printf("┌─────────────────────────────────────────────────────────────────────────────┐\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("│                                                                             │\n");
-		Mono_Printf("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
-		Mono_Printf("│              Send Queue              │             Receive Queue            │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("│                                      │                                      │\n");
-		Mono_Printf("└──────────────────────────────────────┴──────────────────────────────────────┘");
+		Mono_Print("┌─────────────────────────────────────────────────────────────────────────────┐\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("│                                                                             │\n");
+		Mono_Print("├──────────────────────────────────────┬──────────────────────────────────────┤\n");
+		Mono_Print("│              Send Queue              │             Receive Queue            │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│ ID  Ct Type   Data  Name         ACK │ ID  Rd Type   Data  Name         ACK │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("│                                      │                                      │\n");
+		Mono_Print("└──────────────────────────────────────┴──────────────────────────────────────┘");
 	}
 
 	/*------------------------------------------------------------------------
@@ -941,7 +941,7 @@ void CommQueueClass::Mono_Debug_Print2(int refresh)
 			/*.....................................................................
 			Entry isn't active; print blanks
 			.....................................................................*/
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 
@@ -992,7 +992,7 @@ void CommQueueClass::Mono_Debug_Print2(int refresh)
 			/*.....................................................................
 			Entry isn't active; print blanks
 			.....................................................................*/
-			Mono_Printf("____ __                            _");
+			Mono_Print("____ __                            _");
 		}
 	}
 

--- a/TIBERIANDAWN/CONQUER.CPP
+++ b/TIBERIANDAWN/CONQUER.CPP
@@ -2874,7 +2874,7 @@ void CC_Draw_Shape(void const * shapefile, int shapenum, int x, int y, WindowNum
 			}
 			draw_window.Unlock();
 //		} else {
-//			Mono_Printf( "Overrun ShapeBuffer!!!!!!!!!\n" );
+//			Mono_Print( "Overrun ShapeBuffer!!!!!!!!!\n" );
 		}
 	}
 #endif

--- a/TIBERIANDAWN/DEBUG.CPP
+++ b/TIBERIANDAWN/DEBUG.CPP
@@ -596,9 +596,9 @@ void Debug_Key(unsigned input)
 
 			case KN_F6:
 				if (Map.In_Radar(XY_Cell(Map.MapCellX+5, Map.MapCellY - 1))) {
-					Mono_Printf("Arrrggggghhhhh!");
+					Mono_Print("Arrrggggghhhhh!");
 				} else {
-					Mono_Printf("No Arrrggggghhhhh!");
+					Mono_Print("No Arrrggggghhhhh!");
 				}
 				break;
 

--- a/TIBERIANDAWN/INFANTRY.CPP
+++ b/TIBERIANDAWN/INFANTRY.CPP
@@ -1322,7 +1322,7 @@ void InfantryClass::AI(void)
 						return;
 					}
 					if (!Basic_Path()) {
-//Mono_Printf("Infantry Basic_Path is failing.\n");Get_Key();
+//Mono_Print("Infantry Basic_Path is failing.\n");Get_Key();
 						if (Distance(NavCom) < 0x0280 && !IsTethered) {
 							Assign_Destination(TARGET_NONE);
 						} else {

--- a/TIBERIANDAWN/IPXMGR.CPP
+++ b/TIBERIANDAWN/IPXMGR.CPP
@@ -1670,16 +1670,16 @@ void IPXManagerClass::Mono_Debug_Print(int index, int refresh)
 
 	if (refresh) {
 		Mono_Set_Cursor (20,1);
-		Mono_Printf ("IPX Queue:");
+		Mono_Print ("IPX Queue:");
 
 		Mono_Set_Cursor (9,2);
-		Mono_Printf ("Average Response Time:");
+		Mono_Print ("Average Response Time:");
 
 		Mono_Set_Cursor (43,1);
-		Mono_Printf ("Send Overflows:");
+		Mono_Print ("Send Overflows:");
 
 		Mono_Set_Cursor (40,2);
-		Mono_Printf ("Receive Overflows:");
+		Mono_Print ("Receive Overflows:");
 
 	}
 
@@ -1708,7 +1708,7 @@ void IPXManagerClass::Mono_Debug_Print(int index, int refresh)
 	}
 	txt[i] = 0;
 	Mono_Set_Cursor ((80-NumBufs)/2,3);
-	Mono_Printf ("%s",txt);
+	Mono_Print (txt);
 
 #else
 	index = index;

--- a/TIBERIANDAWN/NULLDLG.CPP
+++ b/TIBERIANDAWN/NULLDLG.CPP
@@ -7008,9 +7008,9 @@ void Smart_Printf( char *format, ... )
 	if (Debug_Smart_Print) {
 		if (Special.IsMonoEnabled) {
 //			Mono_Set_Cursor(0,0);
-			Mono_Printf("%s",buf);
+			Mono_Print(buf);
 		} else {
-//			Mono_Printf("%s",buf);
+//			Mono_Print(buf);
 			printf("%s",buf);
 		}
 	} else {
@@ -8235,9 +8235,9 @@ void Smart_Printf( char *format, ... )
 	if (Debug_Smart_Print) {
 		if (Special.IsMonoEnabled) {
 //			Mono_Set_Cursor(0,0);
-			Mono_Printf("%s",buf);
+			Mono_Print(buf);
 		} else {
-//			Mono_Printf("%s",buf);
+//			Mono_Print(buf);
 			printf("%s",buf);
 		}
 	} else {

--- a/TIBERIANDAWN/NULLMGR.CPP
+++ b/TIBERIANDAWN/NULLMGR.CPP
@@ -1119,19 +1119,19 @@ void NullModemClass::Mono_Debug_Print(int, int refresh)
 
 	if (refresh) {
 		Mono_Set_Cursor (31,1);
-		Mono_Printf ("Serial Port Queues");
+		Mono_Print ("Serial Port Queues");
 
 		Mono_Set_Cursor (9,2);
-		Mono_Printf ("Average Response Time:");
+		Mono_Print ("Average Response Time:");
 
 		Mono_Set_Cursor (20,3);
-		Mono_Printf ("CRC Errors:");
+		Mono_Print ("CRC Errors:");
 
 		Mono_Set_Cursor (43,2);
-		Mono_Printf ("Send Overflows:");
+		Mono_Print ("Send Overflows:");
 
 		Mono_Set_Cursor (40,3);
-		Mono_Printf ("Receive Overflows:");
+		Mono_Print ("Receive Overflows:");
 	}
 
 	Mono_Set_Cursor (32,2);

--- a/TIBERIANDAWN/QUEUE.CPP
+++ b/TIBERIANDAWN/QUEUE.CPP
@@ -4033,21 +4033,21 @@ static void Init_Queue_Mono(ConnManClass *net)
 		else {
 			if (NewMonoMode) {
 				Mono_Clear_Screen();
-				Mono_Printf("                         Queue AI:\n");	// flowcount[0]
-				Mono_Printf("                Build Packet Loop:\n");	// flowcount[1]
-				Mono_Printf("                       Frame Sync:\n");	// flowcount[2]
-				Mono_Printf("                Frame Sync Resend:\n");	// flowcount[3]
-				Mono_Printf("               Frame Sync Timeout:\n");	// flowcount[4]
-				Mono_Printf("           Frame Sync New Message:\n");	// flowcount[5]
-				Mono_Printf("                 DoList Execution:\n");	// flowcount[6]
-				Mono_Printf("                  DoList Cleaning:\n");	// flowcount[7]
-				Mono_Printf("\n");
-				Mono_Printf("                            Frame:\n");
-				Mono_Printf("                  MPlayerMaxAhead:\n");
-				Mono_Printf("                       their_recv:\n");
-				Mono_Printf("                       their_sent:\n");
-				Mono_Printf("                          my_sent:\n");
-				Mono_Printf("                 DesiredFrameRate:\n");
+				Mono_Print("                         Queue AI:\n");	// flowcount[0]
+				Mono_Print("                Build Packet Loop:\n");	// flowcount[1]
+				Mono_Print("                       Frame Sync:\n");	// flowcount[2]
+				Mono_Print("                Frame Sync Resend:\n");	// flowcount[3]
+				Mono_Print("               Frame Sync Timeout:\n");	// flowcount[4]
+				Mono_Print("           Frame Sync New Message:\n");	// flowcount[5]
+				Mono_Print("                 DoList Execution:\n");	// flowcount[6]
+				Mono_Print("                  DoList Cleaning:\n");	// flowcount[7]
+				Mono_Print("\n");
+				Mono_Print("                            Frame:\n");
+				Mono_Print("                  MPlayerMaxAhead:\n");
+				Mono_Print("                       their_recv:\n");
+				Mono_Print("                       their_sent:\n");
+				Mono_Print("                          my_sent:\n");
+				Mono_Print("                 DesiredFrameRate:\n");
 				NewMonoMode = 0;
 			}
 		}

--- a/TIBERIANDAWN/UNIT.CPP
+++ b/TIBERIANDAWN/UNIT.CPP
@@ -419,7 +419,7 @@ void UnitClass::AI(void)
 	*/
 	if (*this == UNIT_HOVER) {
 //		Mark_For_Redraw();
-//if (IsDown) Mono_Printf("*");
+//if (IsDown) Mono_Print("*");
 		Mark(MARK_CHANGE);
 	}
 
@@ -2872,7 +2872,7 @@ MoveBitType UnitClass::Blocking_Object(TechnoClass const *techno, CELL cell) con
 				if (face != techface && Distance((AbstractClass const *)techno) > 0x1FF) {
 					return(MOVE_BIT_MOVING_BLOCK);
 				} else {
-//					Mono_Printf("Move No!\r");
+//					Mono_Print("Move No!\r");
 					return(MOVE_BIT_NO);
 				}
 			}


### PR DESCRIPTION
`Mono_Printf("%s", s)` seems to make no sense and thus turn into Mono_Print.
Motivation behind this change is that if I want to change behavior or e.g. `Mono_Printf` I only want to look at the code that actually needs printf and not all the rest.
